### PR TITLE
Fix: update solve export examples AB#16099

### DIFF
--- a/export/export.ipynb
+++ b/export/export.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "source": [
     "## Find a source forecast\n",
-    "You can export data from a single forecast at a time. You'll need to know the full path to the forecast in GMWO. E.g. `/oxford-economics/releases/GEM/Apr23_1`.\n",
+    "You can export data from a single forecast at a time. You'll need to know the full path to the forecast in GMWO. E.g. `\"/oxford-economics/releases/GEM/Oct23_1 25yr\"`.\n",
     "\n",
     "In this example, we use the `/resources` endpoint to find the path to the latest GEM release."
    ]
@@ -180,7 +180,7 @@
     "]\n",
     "\n",
     "exportRequest = {\n",
-    "    # Path to the source forecast\n",
+    "    # Path to the source forecast. If you already know this, then replace with e.g. \"oxford-economics/releases/GEM/Oct23_1 25yr\"\n",
     "    \"InputForecast\": sourceForecast[\"Path\"], \n",
     "\n",
     "    # Range of periods for which to export data\n",
@@ -204,8 +204,8 @@
     "    ## - DatabankCompatible. One row per series, matching format of Global Data Workstation, Excel Data Workstation.\n",
     "    ## - DatabankCompatibleStacked. One row per series and period, matching format of Global Data Workstation, Excel Data Workstation.\n",
     "\n",
-    "    ## Enable/disable aggregation of quarterly data to annual\n",
-    "    # \"AnnualRollup\": false\n",
+    "    ## Enable/disable aggregation of quarterly data to annual (True or False)\n",
+    "    # \"AnnualRollup\": False\n",
     "    \n",
     "}\n",
     "exportOperationResponse = requests.post(f\"{base_url}/v1/operations/export\", headers=headers, json=exportRequest)\n",
@@ -220,7 +220,7 @@
    "metadata": {},
    "source": [
     "## Wait for the export operation to complete\n",
-    "The operation's `await` endpoint is designed to respond as soon as the operation has finished. However, the request can only remain open for a maximum of 1 minute. In case the operation takes longer than this to complete, you should check the status of the returned operation and send repeated requests until it is no longer in progress."
+    "The operation's `await` endpoint is designed to respond as soon as the operation has finished (within 1 minute). You can continue sending `await` requests until the status of the returned operation is no longer in progress, in case the operation takes longer than 1 minute to complete."
    ]
   },
   {
@@ -311,7 +311,7 @@
     "exportFilename = exportFile[\"Filename\"]\n",
     "DownloadGmwoResponse(exportFile[\"DownloadUrl\"], exportFilename)\n",
     "\n",
-    "exportFilename # The file has been downloaded to this location"
+    "exportFilename # This file has been downloaded to the same location as this Python notebook"
    ]
   },
   {
@@ -549,7 +549,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/solve/solve.ipynb
+++ b/solve/solve.ipynb
@@ -47,7 +47,7 @@
    "metadata": {},
    "source": [
     "## Find an input forecast\n",
-    "To solve the model, you'll need an input forecast. You'll need to know the full path to the forecast in GMWO. E.g. `/oxford-economics/releases/GEM/Apr23_1`.\n",
+    "To solve the model, you'll need an input forecast. You'll need to know the full path to the forecast in GMWO. E.g. `\"/oxford-economics/releases/GEM/Oct23_1 25yr\"`.\n",
     "\n",
     "In this example, we use the `/resources` endpoint to find the path to the latest GEM release."
    ]
@@ -107,7 +107,7 @@
     "## Upload model changes (optional)\n",
     "Typically, you'll be making changes to the forecast before solving. These changes can be either:\n",
     "- a set of model commands in *3FS* syntax\n",
-    "- an xlsx workbook containing imposed values for one or more variables\n",
+    "- an xlsx workbook containing imposed values for one or more variables, see example format [`here`](https://my.oxfordeconomics.com/reportaction/DF98456085CB405489340D/Toc)\n",
     "\n",
     "If you have a set of changes in a local file, you'll need to upload them to the GMWO file system before you can use them in a model solution. In this example, we're uploading an import workbook."
    ]
@@ -144,7 +144,7 @@
     "importFileLocal = \"C:\\\\Path\\\\To\\\\My-Changes.xlsx\"\n",
     "importFileGmwo = \"me/My-Changes.xlsx\"\n",
     "multipart_form_data = {\n",
-    "    'file': ('data.xlsx', open(importFileLocal, 'rb')),\n",
+    "    'file': ('data.xlsx', open(importFileLocal, 'rb')), # The name 'data.xlsx' here can be anything \n",
     "    'FileExtension': (None, 'xlsx') # You must provide the 'FileExtension' form value containing the file extension without a dot\n",
     "}\n",
     "\n",
@@ -197,7 +197,7 @@
     "# The solution request body expects JSON of the form below.\n",
     "\n",
     "solveRequest = {\n",
-    "    # Path to the input forecast\n",
+    "    # Path to the input forecast. If you already know this, then replace with e.g. \"oxford-economics/releases/GEM/Oct23_1 25yr\"\n",
     "    \"InputForecast\": sourceForecast[\"Path\"],\n",
     "\n",
     "    # Range of periods to be solved\n",
@@ -244,7 +244,7 @@
    "metadata": {},
    "source": [
     "## Wait for the solve operation to complete\n",
-    "The operation's `await` endpoint is designed to respond as soon as the operation has finished. However, the request can only remain open for a maximum of 1 minute. In case the operation takes longer than this to complete, you should check the status of the returned operation and send repeated requests until it is no longer in progress."
+    "The operation's `await` endpoint is designed to respond as soon as the operation has finished (within 1 minute). You can continue sending `await` requests until the status of the returned operation is no longer in progress, in case the operation takes longer than 1 minute to complete."
    ]
   },
   {
@@ -398,7 +398,7 @@
     }
    ],
    "source": [
-    "outputForecastResource = requests.get(f\"{base_url}/v1/resources/me/path/to/new-forecast\", headers=headers)\n",
+    "outputForecastResource = requests.get(f\"{base_url}/v1/resources/\" + solveRequest[\"OutputForecast\"], headers=headers)\n",
     "outputForecast = outputForecastResource.json()\n",
     "outputForecast"
    ]


### PR DESCRIPTION
Solve
- Small comment clarifying the name of the 'file' in the multipart_form_data for uploading changes that the name can be anything
- Linked the solveRequests OutputForecast inside the request to get the properties of the solved forecast from the resources endpoint
- Added a hyperlink to the template model readable xlsx file on MyOxford

Export
- Small comment to note that the path can be used if already known in the exportRequest "InputForecast"
- Small comment clarifying that the downloaded csv will be saved in the same location as the notebook

Both
- Reworded description of the await endpoint to clarify this a bit better